### PR TITLE
Fix pseudo-code statement

### DIFF
--- a/squashfs/index.html
+++ b/squashfs/index.html
@@ -352,7 +352,7 @@
                     </p>
                     <pre class="pre-scrollable pseudocode example"><code>header = read_u16(offset=offset)
 data_size = header &amp; 0x7FFF
-compressed = header &amp; 0x8000
+compressed = !(header &amp; 0x8000)
 data = read(offset=offset+2, len=data_size)
 if(compressed) {
     data = uncompress(data)


### PR DESCRIPTION
Hello,

First and most importantly, thanks for this documentation. I'm currently an Embedded Linux intern at Bootlin and my latest task was to create a tool to dump a SquashFS image's content, like squashfs-tools-ng but simpler, as a sort of introduction to my main task: add SquashFS support to U-Boot. This documentation was my main reference, as it is clear and straight to the point. Again, thank you.

Finally, when I wrote the code to read metadata blocks, I found out that the proper way to check if the data is compressed or not is actually the opposite of what the pseudo-code in the doc states. Then, I read again the paragraph just above the pseudo-code, and it confirms my supposition. 

I hope this simple contribution will be somehow useful. 
Best regards,
João Marcos