### PR TITLE
Fix Extended Directory description

### DIFF
--- a/squashfs/index.html
+++ b/squashfs/index.html
@@ -777,7 +777,7 @@ return data</code></pre>
                                     <tr>
                                         <td>index_count</td>
                                         <td>u16</td>
-                                        <td>One less than the number of directory index entries following the inode structure</td>
+                                        <td>The number of directory index entries following the inode structure</td>
                                     </tr>
                                     <tr>
                                         <td>block_offset</td>
@@ -791,7 +791,7 @@ return data</code></pre>
                                     </tr>
                                     <tr>
                                         <td>index</td>
-                                        <td>dir_index_t[index_count + 1]</td>
+                                        <td>dir_index_t[index_count]</td>
                                         <td>A list of <a href="#directory-index">directory index</a> entries for faster lookup in the directory table</td>
                                     </tr>
                                 </tbody>

--- a/squashfs/index.html
+++ b/squashfs/index.html
@@ -1058,6 +1058,9 @@ return data</code></pre>
                         For each directory inode, the directory table stores a list of all entries stored inside, with references back to the inodes that describe those entries.
                     </p>
                     <p>
+                        The directory inodes store the total, uncompressed size of the entire listing, including headers. Using this size, a SquashFS reader can determine if another header with further entries should be following once it reaches the end of a run.
+                    </p>
+                    <p>
                         The entry list is self is sorted ASCIIbetically by entry name. To save space, a delta encoding is used to store the inode number, i.e. the list is preceeded by a header with a reference inode number and all entries store the difference to that. Furthermore, the header also includes the location of a metadata block that the inodes of all of the following entries are in. The entries just store an offset into the uncompressed metadata block.
                     </p>
                     <h4 id="directory-header">Directory Header</h4>


### PR DESCRIPTION
Hello!
According to the current state of the Extended Directory description, one should use the index + 1 to read the 'index' property of such inode, and also offset the index_count by +1. Someone sent an email to the U-Boot's mailing list mentioning this issue: https://github.com/AgentD/squashfs-tools-ng/commit/e6588526838caece9529 and after fixing this detail in the code, I could finally read SquashFS images containing such inode type without any bugs. I hope you find this fix useful!

Best regards,