### PR TITLE
Fix xattr key entry name_size

### DIFF
--- a/squashfs/index.html
+++ b/squashfs/index.html
@@ -1320,7 +1320,7 @@ return data</code></pre>
                             <tr>
                                 <td>name_size</td>
                                 <td>u16</td>
-                                <td>The size of the key name <b>including</b> the omitted prefix but excluding the trailing null byte</td>
+                                <td>The size of the key name <b>excluding</b> the omitted prefix and the trailing null byte</td>
                             </tr>
                             <tr>
                                 <td>name</td>


### PR DESCRIPTION
Squashfs xattr key entry name_size did't count the prefix according to https://github.com/AgentD/squashfs-tools-ng/blob/master/lib/sqfs/xattr/xattr_reader.c#L218.
