### PR TITLE
fix s32 → u32 for directory header → inode number

### DIFF
--- a/squashfs/squashfs.adoc
+++ b/squashfs/squashfs.adoc
@@ -817,7 +817,7 @@ The directory header has the following structure:
 | u32 | start | The location of the metadata block in the inode table
                 where the inodes are stored. This is relative to the
                 inode table start from the super block.
-| s32 | inode number | An arbitrary inode number. The entries that follow
+| u32 | inode number | An arbitrary inode number. The entries that follow
                        store their inode number as a difference to this.
 |===
 

--- a/squashfs/squashfs.html
+++ b/squashfs/squashfs.html
@@ -2384,7 +2384,7 @@ and picking of the reference could of course be optimized to prevent this.</p>
 </div></div></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">s32</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">u32</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">inode number</p></td>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
 <p>An arbitrary inode number. The entries that follow


### PR DESCRIPTION
Upstream reference, unchanged since the initial revision from 17 years ago:

https://github.com/plougher/squashfs-tools/blame/e433979377e148ccbc9a3f1d43d5ae6271ea0e7f/squashfs-tools/squashfs_fs.h#L472