### PR TITLE
Fix LZMA/LZO IDs

### DIFF
--- a/squashfs/squashfs.adoc
+++ b/squashfs/squashfs.adoc
@@ -219,8 +219,8 @@ including the locations of other sections.
 !===
 ! Value ! Name ! Comment
 ! 1 ! GZIP ! just zlib streams (no gzip headers\!)
-! 2 ! LZO  !
-! 3 ! LZMA ! LZMA version 1
+! 2 ! LZMA ! LZMA version 1
+! 3 ! LZO  !
 ! 4 ! XZ   ! LZMA version 2 as used by xz-utils
 ! 5 ! LZ4  !
 ! 6 ! ZSTD !


### PR DESCRIPTION
The LZMA and LZO IDs are inverted, correct one: https://github.com/plougher/squashfs-tools/blob/b41015dc6cd55c6c21a4a5dbd4b8ed80cf5367eb/squashfs-tools/squashfs_fs.h#L286-L287