### PR TITLE
Clarify section 2.2

### DIFF
--- a/squashfs/squashfs.html
+++ b/squashfs/squashfs.html
@@ -595,7 +595,7 @@ block after compression never exceeds the input block size.</p>
 <div class="sect2">
 <h3 id="_packing_metadata">2.2. Packing Metadata</h3>
 <div class="paragraph">
-<p>Metadata (e.g. inodes, directory listings, etc&#8230;&#8203;) is treated as a continuous
+<p>Metadata (inodes and directory listings) is treated as a continuous
 stream of records that is chopped up into 8KiB blocks that are separately
 compressed into special metadata blocks.</p>
 </div>


### PR DESCRIPTION
Remove the ambiguity of what tables are metadata tables. The only metadata tables are the inode table and directory table, so there is no point in specifying "etc". This makes it seem as if more tables are metadata tables, which there are not.